### PR TITLE
patch 0.1.1

### DIFF
--- a/exposurescout/scripts/Users.sh
+++ b/exposurescout/scripts/Users.sh
@@ -4,6 +4,6 @@
 # Last Update: 24-09-2024
 # Description: Get all users (name, uid and groups id they are in) as $uid$($name$):$gid$(,$gid$)*
 
-cut -d":" -f1 /etc/passwd 2>/dev/null| while read i; do id $i;done 2>/dev/null | sed "s/uid=//" | sed "s/ gid=.*) groups=/:/" | sed "s/([_A-Za-z\-]*)//2g"
+cut -d":" -f1 /etc/passwd 2>/dev/null| while read i; do id $i;done 2>/dev/null | sed "s/uid=//" | sed "s/ gid=.*) groups=/:/" | sed "s/ gid=.*) groupes=/:/" | sed "s/([_A-Za-z\-]*)//2g"
 
 # output example: 1000(user):1000,24,25,27,29

--- a/exposurescout/scripts/Users.sh
+++ b/exposurescout/scripts/Users.sh
@@ -4,6 +4,6 @@
 # Last Update: 24-09-2024
 # Description: Get all users (name, uid and groups id they are in) as $uid$($name$):$gid$(,$gid$)*
 
-cut -d":" -f1 /etc/passwd 2>/dev/null| while read i; do id $i;done 2>/dev/null | sed "s/uid=//" | sed "s/ gid=.*) groups=/:/" | sed "s/ gid=.*) groupes=/:/" | sed "s/([_A-Za-z\-]*)//2g"
+cut -d":" -f1 /etc/passwd 2>/dev/null| while read i; do id $i;done 2>/dev/null | sed "s/uid=//" | sed "s/ gid=.*) groups=/:/" | sed "s/ gid=.*) groupes=/:/" | sed "s/([_0-9A-Za-z\-]*)//2g"
 
 # output example: 1000(user):1000,24,25,27,29


### PR DESCRIPTION
Debian update implied a modification on how data are encoded in _/etc/passwd_ depending on the language used on the machine. e.g.: _groups_ in English, _groupes_ in French.
The script collecting users has been modified patching this issue for FR and EN languages.

It still must be checked later for NL.