### PR TITLE
patch 0.1.2

### DIFF
--- a/exposurescout/modules/FileSystemCollector.py
+++ b/exposurescout/modules/FileSystemCollector.py
@@ -9,7 +9,7 @@ Authors:
 Nathan Amorison
 
 Version:
-0.1.0
+0.1.3
 """
 
 
@@ -747,7 +747,7 @@ class LinFileSystemCollector(ACollector):
 		Inherits from ACollector
 	"""
 
-	snapshot_elemnt_id = "\x01"
+	snapshot_elemnt_id = b"\x01"
 	name = "File System Collector"
 	description = """
 			For Linux/Unix platforms only.

--- a/exposurescout/scripts/Users.sh
+++ b/exposurescout/scripts/Users.sh
@@ -4,6 +4,6 @@
 # Last Update: 24-09-2024
 # Description: Get all users (name, uid and groups id they are in) as $uid$($name$):$gid$(,$gid$)*
 
-cut -d":" -f1 /etc/passwd 2>/dev/null| while read i; do id $i;done 2>/dev/null | sed "s/uid=//" | sed "s/ gid=.*) groups=/:/" | sed "s/([_A-Za-z\-]*)//2g"
+cut -d":" -f1 /etc/passwd 2>/dev/null| while read i; do id $i;done 2>/dev/null | sed "s/uid=//" | sed "s/ gid=.*) groups=/:/" | sed "s/ gid=.*) groupes=/:/" | sed "s/([_A-Za-z\-]*)//2g"
 
 # output example: 1000(user):1000,24,25,27,29

--- a/exposurescout/scripts/Users.sh
+++ b/exposurescout/scripts/Users.sh
@@ -4,6 +4,6 @@
 # Last Update: 24-09-2024
 # Description: Get all users (name, uid and groups id they are in) as $uid$($name$):$gid$(,$gid$)*
 
-cut -d":" -f1 /etc/passwd 2>/dev/null| while read i; do id $i;done 2>/dev/null | sed "s/uid=//" | sed "s/ gid=.*) groups=/:/" | sed "s/ gid=.*) groupes=/:/" | sed "s/([_A-Za-z\-]*)//2g"
+cut -d":" -f1 /etc/passwd 2>/dev/null| while read i; do id $i;done 2>/dev/null | sed "s/uid=//" | sed "s/ gid=.*) groups=/:/" | sed "s/ gid=.*) groupes=/:/" | sed "s/([_0-9A-Za-z\-]*)//2g"
 
 # output example: 1000(user):1000,24,25,27,29


### PR DESCRIPTION
Debian update implied a modification on how data are encoded in /etc/passwd depending on the language used on the machine. e.g.: groups in English, groupes in French.
The script collecting users has been modified patching this issue for FR and EN languages.

It still must be checked later for NL.

Previous script version also was not able to spot users with numbers in it (e.g.: _iperf3_). It has been fixed now.