### PR TITLE
Patch 0.1.4

### DIFF
--- a/exposurescout/modules/FileSystemCollector.py
+++ b/exposurescout/modules/FileSystemCollector.py
@@ -9,7 +9,7 @@ Authors:
 Nathan Amorison
 
 Version:
-0.1.3
+0.1.4
 """
 
 
@@ -763,13 +763,13 @@ class LinFileSystemCollector(ACollector):
 			return False
 
 		if self.raw_result and o.raw_result:
-			if len(self.raw_result) != len(o.raw_result):
+			if len(self.raw_result[File.element_name]) != len(o.raw_result[File.element_name]):
 				return False
 		else:
 			return False
 
-		for d in self.raw_result:
-			if d not in o.raw_result:
+		for d in self.raw_result[File.element_name]:
+			if d not in o.raw_result[File.element_name]:
 				return False
 
 		return True
@@ -799,7 +799,7 @@ class LinFileSystemCollector(ACollector):
 		Returns:
 			A list of files or directories.
 		"""
-		return self.raw_result
+		return self.raw_result[File.element_name]
 
 	def import_bin(self, data):
 		"""
@@ -823,7 +823,7 @@ class LinFileSystemCollector(ACollector):
 			file, rest = File.from_bytes(rest)
 			files.append(file)
 
-		self.raw_result = files
+		self.raw_result = {File.element_name:files}
 
 	def import_db(self, db_cursor, run_id):
 		"""
@@ -860,7 +860,7 @@ class LinFileSystemCollector(ACollector):
 
 			return content
 
-		self.raw_result = macro(db_cursor, run_id, None)
+		self.raw_result = {File.element_name:macro(db_cursor, run_id, None)}
 
 	def _export_sql(self, db_cursor, run_id):
 		"""
@@ -894,7 +894,7 @@ class LinFileSystemCollector(ACollector):
 		# Add the files
 		query = f"""INSERT INTO files VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 
-		for file in self.raw_result:
+		for file in self.raw_result[File.element_name]:
 			directories = []
 			if file.is_dir():
 				directories.append(file)
@@ -920,11 +920,11 @@ class LinFileSystemCollector(ACollector):
 		encoded_data = b""
 
 		# store the number of files/directories collected
-		file_number = len(self.raw_result)
+		file_number = len(self.raw_result[File.element_name])
 		encoded_data += VarInt.to_bytes(file_number)
 
 		# for every file collected, encode it
-		for file in self.raw_result:
+		for file in self.raw_result[File.element_name]:
 			encoded_data += file.to_bytes()
 
 		self.result = encoded_data
@@ -998,9 +998,9 @@ class LinFileSystemCollector(ACollector):
 			t.join()
 
 
-		self.raw_result = []
+		self.raw_result = {File.element_name:[]}
 		for t in threads:
-			self.raw_result.append(t.result)
+			self.raw_result[File.element_name].append(t.result)
 
 	def make_diff(run_id_a, run_id_b, a, b, report):
 		"""

--- a/exposurescout/tests/test_FileSystemCollector.py
+++ b/exposurescout/tests/test_FileSystemCollector.py
@@ -8,7 +8,7 @@ Authors:
 Nathan Amorison
 
 Version:
-0.1.0
+0.1.4
 """
 
 from .. import modules
@@ -202,7 +202,7 @@ class TestLinFileSystemCollector(unittest.TestCase):
 		directory.size = 4096
 		directory.metadata_hash = b"\xde#\x1e\xf5\x06P\x0e\x92f\x1c/E\xef\x81\xe4`"
 
-		expected = [directory]
+		expected = {FSCollector.File.element_name:[directory]}
 
 		self.assertEqual(result, expected)
 
@@ -233,7 +233,7 @@ class TestLinFileSystemCollector(unittest.TestCase):
 		directory.append_all([file1, file2])
 		directory.inode = 968624
 
-		collector_a.raw_result = [directory]
+		collector_a.raw_result = {FSCollector.File.element_name:[directory]}
 
 
 		expected = report.DiffReport(run_id_a, run_id_b)
@@ -253,7 +253,7 @@ class TestLinFileSystemCollector(unittest.TestCase):
 		self.assertEqual(result, expected)
 
 		collector_b = FSCollector.LinFileSystemCollector()
-		collector_b.raw_result = [self.directory]
+		collector_b.raw_result = {FSCollector.File.element_name:[self.directory]}
 
 		expected.diff_elemnts = {
 			'File System Collector': {
@@ -301,7 +301,7 @@ class TestLinFileSystemCollector(unittest.TestCase):
 		directory.append_all([file1, file2])
 		directory.inode = 968624
 
-		collector_a.raw_result = [directory]
+		collector_a.raw_result = {FSCollector.File.element_name:[directory]}
 
 		expected = report.DiffReport(run_id_a, run_id_b)
 		expected.diff_elemnts = {
@@ -376,7 +376,7 @@ class TestLinFileSystemCollector(unittest.TestCase):
 		directory.append_all([file1, file2])
 		directory.inode = 968624
 
-		collector.raw_result = [directory]
+		collector.raw_result = {FSCollector.File.element_name:[directory]}
 
 
 		conn = sql.connect(":memory:")
@@ -427,7 +427,7 @@ class TestLinFileSystemCollector(unittest.TestCase):
 		directory.append_all([file1, file2])
 		directory.inode = 968624
 
-		collector_a.raw_result = [directory]
+		collector_a.raw_result = {FSCollector.File.element_name:[directory]}
 
 
 		conn = sql.connect(":memory:")
@@ -459,7 +459,7 @@ class TestLinFileSystemCollector(unittest.TestCase):
 
 		collector_a = FSCollector.LinFileSystemCollector()
 		collector_b = FSCollector.LinFileSystemCollector()
-		collector_b.raw_result = [self.directory]
+		collector_b.raw_result = {FSCollector.File.element_name:[self.directory]}
 
 
 		# hard code values so we have control over values that are tested
@@ -479,7 +479,7 @@ class TestLinFileSystemCollector(unittest.TestCase):
 		directory.append_all([file1, file2])
 		directory.inode = 968624
 
-		collector_a.raw_result = [directory]
+		collector_a.raw_result = {FSCollector.File.element_name:[directory]}
 
 		expected = report.DiffReport(run_id_a, run_id_b)
 		expected.diff_elemnts = {

--- a/exposurescout/tests/test_UsersCollector.py
+++ b/exposurescout/tests/test_UsersCollector.py
@@ -8,7 +8,7 @@ Authors:
 Nathan Amorison
 
 Version:
-0.0.1
+0.1.4
 """
 
 from .. import modules
@@ -104,7 +104,7 @@ class TestLinUsersCollector(unittest.TestCase):
 		sudoers = [UsersCollector.Sudoer(1000)]
 		md5 = tools.get_file_hash("./exposurescout/tests/hash_test_file.txt")
 
-		collector.raw_result = [users, groups, sudoers, md5, md5]
+		collector.raw_result = {UsersCollector.User.element_name:users, UsersCollector.Group.element_name:groups, UsersCollector.Sudoer.element_name:sudoers, "passwd_hash":md5, "group_hash":md5}
 
 		expected = b"\x00\x20\x64\x02\x23\xe8\x04user\x05\x23\xe8\x18\x19\x1b\x1d\x00\x04root\x01\x00\x06\x23\xe8\x04user\x00\x04root\x18\x05cdrom\x19\x06floppy\x1b\x04sudo\x1d\x05audio\x01\x23\xe8\x8d\xdd\x8b\xe4\xb1\x79\xa5\x29\xaf\xa5\xf2\xff\xae\x4b\x98\x58\x8d\xdd\x8b\xe4\xb1\x79\xa5\x29\xaf\xa5\xf2\xff\xae\x4b\x98\x58"
 

--- a/exposurescout/tests/test_report.py
+++ b/exposurescout/tests/test_report.py
@@ -8,7 +8,7 @@ Authors:
 Nathan Amorison
 
 Version:
-0.0.1
+0.1.4
 """
 
 from ..modules import LinUsersCollector, User, Group, Sudoer
@@ -118,8 +118,8 @@ class TestDiffReport(unittest.TestCase):
 		sudoers = [Sudoer(1000)]
 		md5 = tools.get_file_hash("./exposurescout/tests/hash_test_file.txt")
 
-		uc_a.raw_result = [users.copy(), groups.copy(), sudoers.copy(), md5, md5]
-		uc_b.raw_result = [users.copy(), groups.copy(), sudoers.copy(), md5, md5]
+		uc_a.raw_result = {User.element_name:users.copy(), Group.element_name:groups.copy(), Sudoer.element_name:sudoers.copy(), "passwd_hash":md5, "group_hash":md5}
+		uc_b.raw_result = {User.element_name:users.copy(), Group.element_name:groups.copy(), Sudoer.element_name:sudoers.copy(), "passwd_hash":md5, "group_hash":md5}
 
 		result = DiffReport(run_id_a, run_id_b)
 
@@ -134,9 +134,9 @@ class TestDiffReport(unittest.TestCase):
 		new_group = Group(1001, "test")
 		new_sudoer = Sudoer(1001)
 
-		uc_b.raw_result[0].append(new_user)
-		uc_b.raw_result[1].append(new_group)
-		uc_b.raw_result[2].append(new_sudoer)
+		uc_b.raw_result[User.element_name].append(new_user)
+		uc_b.raw_result[Group.element_name].append(new_group)
+		uc_b.raw_result[Sudoer.element_name].append(new_sudoer)
 
 		LinUsersCollector.make_diff(run_id_a, run_id_b, uc_a, uc_b, result)
 
@@ -160,17 +160,17 @@ class TestDiffReport(unittest.TestCase):
 
 		result = DiffReport(run_id_a, run_id_b)
 
-		uc_a.raw_result = [[User(1000, "user", [1000,24,25,27,29])], groups.copy(), sudoers.copy(), md5, md5]
-		uc_b.raw_result = [[User(1000, "user", [1000,24,25,27,29])], groups.copy(), sudoers.copy(), md5, md5]
+		uc_a.raw_result = {User.element_name:[User(1000, "user", [1000,24,25,27,29])], Group.element_name:groups.copy(), Sudoer.element_name:sudoers.copy(), "passwd_hash":md5, "group_hash":md5}
+		uc_b.raw_result = {User.element_name:[User(1000, "user", [1000,24,25,27,29])], Group.element_name:groups.copy(), Sudoer.element_name:sudoers.copy(), "passwd_hash":md5, "group_hash":md5}
 
 		new_user = User(1001, "test", [1001])
 		new_group = Group(1001, "test")
 		new_sudoer = Sudoer(1001)
 
-		uc_a.raw_result[0].append(new_user)
-		uc_a.raw_result[1].append(new_group)
-		uc_a.raw_result[2].append(new_sudoer)
-		uc_b.raw_result[0][0].groups.append(1001)
+		uc_a.raw_result[User.element_name].append(new_user)
+		uc_a.raw_result[Group.element_name].append(new_group)
+		uc_a.raw_result[Sudoer.element_name].append(new_sudoer)
+		uc_b.raw_result[User.element_name][0].groups.append(1001)
 
 		LinUsersCollector.make_diff(run_id_a, run_id_b, uc_a, uc_b, result)
 
@@ -179,7 +179,7 @@ class TestDiffReport(unittest.TestCase):
 			LinUsersCollector.name : {
 				User.element_name:[
 					DiffElement(run_id_a, users[0], MODIFIED),
-					DiffElement(run_id_b, uc_b.raw_result[0][0], MODIFIED),
+					DiffElement(run_id_b, uc_b.raw_result[User.element_name][0], MODIFIED),
 					DiffElement(run_id_a, new_user, DELETED),
 				],
 				Group.element_name: [


### PR DESCRIPTION
# Patch 0.1.4
Raw colected data `raw_result` in [collectors](https://github.com/Tirette-hub/ExposureScout/blob/main/docs/COLLECTOR.md#acollector) were list of collectibles but not ordered properly. For example, [LinUsersCollector](https://github.com/Tirette-hub/ExposureScout/blob/main/docs/COLLECTOR.md#acollector) was using a list containing a [User](https://github.com/Tirette-hub/ExposureScout/blob/main/docs/USERSCOLLECTOR.md#useruid-name-groups) list, a [Group](https://github.com/Tirette-hub/ExposureScout/blob/main/docs/USERSCOLLECTOR.md#groupgid-name) list, a [Sudoer](https://github.com/Tirette-hub/ExposureScout/blob/main/docs/USERSCOLLECTOR.md#sudoeruid) list, the _/etc/passwd_ file hash, the _/etc/group_ file hash, whereas the [LinFileSystemCollector](https://github.com/Tirette-hub/ExposureScout/blob/main/docs/FSCOLLECTOR.md#linfilesystemcollector) was using a list of [File](https://github.com/Tirette-hub/ExposureScout/blob/main/docs/FSCOLLECTOR.md#filepath-metadata-size-content_hash) objects.\
Accessing to data themselves in a generic manner was therefore difficult. Perhaps further developed code such as the Filter may need to acces those data in a generic manner, this is why I switched from this old data structure to the new one:\
It now uses a `dict` object in which every key is the name of an element type that is collected by the collector and the value associated to this key is the list of the collected elements of this type.