### PR TITLE
Patch 3.2

### DIFF
--- a/exposurescout/core/analysis_manager.py
+++ b/exposurescout/core/analysis_manager.py
@@ -9,7 +9,7 @@ Authors:
 Nathan Amorison
 
 Version:
-0.2.2
+0.3.2
 """
 
 import time

--- a/exposurescout/tests/test_FileSystemCollector.py
+++ b/exposurescout/tests/test_FileSystemCollector.py
@@ -150,7 +150,10 @@ class TestLinFileSystemCollector(unittest.TestCase):
 		directory = FSCollector.Directory(test_directory, metadata)
 		directory.append_all([file1, file2])
 
-		expected += directory.to_bytes()
+		encoded = b"\x01" + directory.to_bytes()
+
+		expected += VarInt.to_bytes(len(encoded))
+		expected += encoded
 
 		self.assertEqual(result, expected)
 


### PR DESCRIPTION
# Patch 3.2
## _LinFileSystemCollector_
- (Fixed) Header was not properly exported. The saved snapshot files were then corrupted and it was impossible to read them.
- (Fixed) Some string data have weird encoding that is not necessarily detected (_b'\xe2\x80\xaf'_ has the same string length as _b'\x20'_ which is the encoded value of a space character) which implied issues when saving snapshots since it is based on data length. It now encodes the length of the data based on the encoded data itself instead of the raw string data.